### PR TITLE
Add campaign start end date

### DIFF
--- a/localcoin/sources/registry.move
+++ b/localcoin/sources/registry.move
@@ -44,7 +44,8 @@ module localcoin::registry {
         proprietor: String,
         phone_no: String,
         store_name: String,
-        location: String
+        store_image: String,
+        location: String,
     }
 
     // === Init Function ===
@@ -72,7 +73,8 @@ module localcoin::registry {
     public fun merchant_registration (
         proprietor: String, 
         phone_no: String, 
-        store_name: String, 
+        store_name: String,
+        store_image: String, 
         location: String,
         reg: &mut MerchantRegistry,
         ctx: &mut TxContext
@@ -90,6 +92,7 @@ module localcoin::registry {
             proprietor: proprietor,
             phone_no: phone_no,
             store_name: store_name,
+            store_image: store_image,
             location: location
         };
 
@@ -147,7 +150,8 @@ module localcoin::registry {
         merchant_addr: address,
         proprietor: String, 
         phone_no: String, 
-        store_name: String, 
+        store_name: String,
+        store_image: String, 
         location: String
     ) {
         assert!(vector::contains(& reg.unverified_merchants, &merchant_addr) == true ||
@@ -160,6 +164,7 @@ module localcoin::registry {
         merchant_details.proprietor = proprietor;
         merchant_details.phone_no = phone_no;
         merchant_details.store_name = store_name;
+        merchant_details.store_image = store_image;
         merchant_details.location = location;
 
         if (verified_status == false) {

--- a/localcoin/tests/registry_tests.move
+++ b/localcoin/tests/registry_tests.move
@@ -30,7 +30,7 @@ module localcoin::registry_tests {
         {
             let mut merchantRegistry = test_scenario::take_shared<MerchantRegistry>(&scenario);
 
-            registry::merchant_registration(string::utf8(b"Bob"), string::utf8(b"9813214354"), string::utf8(b"Bob Store"), string::utf8(b"Kathmandu"), &mut merchantRegistry, test_scenario::ctx(&mut scenario));
+            registry::merchant_registration(string::utf8(b"Bob"), string::utf8(b"9813214354"), string::utf8(b"Bob Store"), string::utf8(b"Store Image Url"), string::utf8(b"Kathmandu"), &mut merchantRegistry, test_scenario::ctx(&mut scenario));
 
             test_scenario::return_shared(merchantRegistry);
         };
@@ -86,7 +86,7 @@ module localcoin::registry_tests {
             let superAdmin = test_scenario::take_from_sender<SuperAdminCap>(&scenario);
             let mut merchantRegistry = test_scenario::take_shared<MerchantRegistry>(&scenario);
 
-            registry::update_merchant_info(&superAdmin, &mut merchantRegistry, true, merchant, string::utf8(b"Bob"), string::utf8(b"9813214354"), string::utf8(b"Bob new Store"), string::utf8(b"Kathmandu"));
+            registry::update_merchant_info(&superAdmin, &mut merchantRegistry, true, merchant, string::utf8(b"Bob"), string::utf8(b"9813214354"), string::utf8(b"Bob new Store"), string::utf8(b"Store image"), string::utf8(b"Kathmandu"));
 
             test_scenario::return_to_address(admin, superAdmin);
             test_scenario::return_shared(merchantRegistry);
@@ -109,7 +109,7 @@ module localcoin::registry_tests {
             let superAdmin = test_scenario::take_from_sender<SuperAdminCap>(&scenario);
             let mut merchantRegistry = test_scenario::take_shared<MerchantRegistry>(&scenario);
 
-            registry::update_merchant_info(&superAdmin, &mut merchantRegistry, false, merchant, string::utf8(b"Bob"), string::utf8(b"9813214354"), string::utf8(b"Bob new Store"), string::utf8(b"Kathmandu"));
+            registry::update_merchant_info(&superAdmin, &mut merchantRegistry, false, merchant, string::utf8(b"Bob"), string::utf8(b"9813214354"), string::utf8(b"Bob new Store"), string::utf8(b"Store image"), string::utf8(b"Kathmandu"));
 
             test_scenario::return_to_address(admin, superAdmin);
             test_scenario::return_shared(merchantRegistry);
@@ -148,7 +148,7 @@ module localcoin::registry_tests {
         {
             let mut merchantRegistry = test_scenario::take_shared<MerchantRegistry>(&scenario);
 
-            registry::merchant_registration(string::utf8(b"Bob"), string::utf8(b"9813214354"), string::utf8(b"Bob Store"), string::utf8(b"Kathmandu"), &mut merchantRegistry, test_scenario::ctx(&mut scenario));
+            registry::merchant_registration(string::utf8(b"Bob"), string::utf8(b"9813214354"), string::utf8(b"Bob Store"), string::utf8(b"Store Image Url"), string::utf8(b"Kathmandu"), &mut merchantRegistry, test_scenario::ctx(&mut scenario));
 
             test_scenario::return_shared(merchantRegistry);
         };
@@ -158,7 +158,7 @@ module localcoin::registry_tests {
         {
             let mut merchantRegistry = test_scenario::take_shared<MerchantRegistry>(&scenario);
 
-            registry::merchant_registration(string::utf8(b"Bob"), string::utf8(b"9813214354"), string::utf8(b"Bob Store"), string::utf8(b"Kathmandu"), &mut merchantRegistry, test_scenario::ctx(&mut scenario));
+            registry::merchant_registration(string::utf8(b"Bob"), string::utf8(b"9813214354"), string::utf8(b"Bob Store"), string::utf8(b"Store Image Url"), string::utf8(b"Kathmandu"), &mut merchantRegistry, test_scenario::ctx(&mut scenario));
 
             test_scenario::return_shared(merchantRegistry);
         };
@@ -219,7 +219,7 @@ module localcoin::registry_tests {
             let superAdmin = test_scenario::take_from_sender<SuperAdminCap>(&scenario);
             let mut merchantRegistry = test_scenario::take_shared<MerchantRegistry>(&scenario);
 
-            registry::update_merchant_info(&superAdmin, &mut merchantRegistry, false, merchant, string::utf8(b"Bob"), string::utf8(b"9813214354"), string::utf8(b"Bob new Store"), string::utf8(b"Kathmandu"));
+            registry::update_merchant_info(&superAdmin, &mut merchantRegistry, false, merchant, string::utf8(b"Bob"), string::utf8(b"9813214354"), string::utf8(b"Bob new Store"), string::utf8(b"Store image"), string::utf8(b"Kathmandu"));
 
             test_scenario::return_to_address(admin, superAdmin);
             test_scenario::return_shared(merchantRegistry);
@@ -249,7 +249,7 @@ module localcoin::registry_tests {
         {
             let mut merchantRegistry = test_scenario::take_shared<MerchantRegistry>(&scenario);
 
-            registry::merchant_registration(string::utf8(b"Bob"), string::utf8(b"9813214354"), string::utf8(b"Bob Store"), string::utf8(b"Kathmandu"), &mut merchantRegistry, test_scenario::ctx(&mut scenario));
+            registry::merchant_registration(string::utf8(b"Bob"), string::utf8(b"9813214354"), string::utf8(b"Bob Store"), string::utf8(b"Store Image Url"), string::utf8(b"Kathmandu"), &mut merchantRegistry, test_scenario::ctx(&mut scenario));
 
             test_scenario::return_shared(merchantRegistry);
         };


### PR DESCRIPTION
Following changes are made in this PR:

- Added campaign start and end dates , campaign category fields in CampaignDetails struct
- Added amount param in request_settlement function
- Added store_url field in MerchantDetails struct